### PR TITLE
Installer fixes and changes

### DIFF
--- a/lib/DbEngine.php
+++ b/lib/DbEngine.php
@@ -87,7 +87,7 @@ class DbEngine
             $this->host = $conf['dbserver'];
             $this->password = $conf['dbpass'];
             $this->username = $conf['dbuser'];
-            $this->port = $conf['dbconf'];
+            $this->port = $conf['dbport'];
             $this->dbname = $conf['dbname'];
             $this->db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
             $this->prefix = (defined('DB_PREFIX') ? DB_PREFIX : 'ezrpg');

--- a/lib/DbFactory.php
+++ b/lib/DbFactory.php
@@ -52,7 +52,7 @@ class DbFactory
         }else{
             $dbconfig = $config;
         }
-        $dbconfig['dsn'] = $dbconfig['dbdriver'] . ":dbname=" . $dbconfig['dbname'] . ";host=" . $dbconfig['dbserver'] . ";port=" . $dbconfig['dbport'];
+        $dbconfig['dsn'] = "mysql:dbname=" . $dbconfig['dbname'] . ";host=" . $dbconfig['dbserver'] . ";port=" . $dbconfig['dbport'];
         return new \ezRPG\lib\DbEngine($dbconfig);
     }
 

--- a/web/install/modules/Config/index.php
+++ b/web/install/modules/Config/index.php
@@ -18,6 +18,7 @@ class Install_Config extends InstallerFactory
             $dbconfig['dbname'] = "ezrpg";
             $dbconfig['dbport'] = "3306";
             $dbconfig['dbpass'] = "ezrpg_";
+            $dbconfig['dbprefix'] = "ezrpg_";
         }
         else
         {

--- a/web/install/modules/CreateAdmin/index.php
+++ b/web/install/modules/CreateAdmin/index.php
@@ -47,7 +47,6 @@ class Install_CreateAdmin extends InstallerFactory
 
             if ( $errors == 0 )
             {
-                require_once ROOT_DIR . '/config.php';
                 require_once ROOT_DIR . "/lib/functions/func.rand.php";
                 try
                 {

--- a/web/install/modules/CreateAdmin/index.php
+++ b/web/install/modules/CreateAdmin/index.php
@@ -39,10 +39,10 @@ class Install_CreateAdmin extends InstallerFactory
                 $errors = 1;
                 $msg .= 'You didn\'t verify your password correctly.';
             }
-            if ( !preg_match("/[a-zA-Z0-9\W]{6}+/", $password) )
+            if ( strlen($password) < 6 )
             {
                 $errors = 1;
-                $msg .= 'Password is invalid';
+                $msg .= 'Password must be at least 6 characters long.';
             }
 
             if ( $errors == 0 )

--- a/web/install/modules/Plugins/index.php
+++ b/web/install/modules/Plugins/index.php
@@ -21,7 +21,6 @@ class Install_Plugins extends InstallerFactory
             $this->footer();
             die;
         }
-        require_once ROOT_DIR . '/config.php';
         try
         {
             $this->container['app']->getConfig(ROOT_DIR . '/config.php');

--- a/web/install/modules/Populate/index.php
+++ b/web/install/modules/Populate/index.php
@@ -25,7 +25,6 @@ class Install_Populate extends InstallerFactory
             $this->footer();
             die;
         }
-        require_once ROOT_DIR . '/config.php';
 		try
         {
             $this->container['app']->getConfig(ROOT_DIR . '/config.php');


### PR DESCRIPTION
The DbFactory uses the `dbdriver` parameter from Installer when later constructing the dsn which doesn't make sense, since PDO or MySQLi is an abstraction layer and not a database driver.

Also added dbprefix to make sure it's defined, elsewhy it breaks.